### PR TITLE
Fix Spanish auto translations

### DIFF
--- a/locale/es-es/test.dialog
+++ b/locale/es-es/test.dialog
@@ -1,2 +1,2 @@
 # auto translated from en-us to es-es
-este es un diálogo {test} a {{test}} cosas
+éste es un diálogo de {test} para {{test}} cosas

--- a/locale/es-es/test.intent
+++ b/locale/es-es/test.intent
@@ -1,2 +1,2 @@
 # auto translated from en-us to es-es
-este es un intento de prueba
+ésta es una intención de prueba


### PR DESCRIPTION
I kept `test.rx` and `test.value` since it seems they shouldn't be translated